### PR TITLE
Plus should be removed before decoding.

### DIFF
--- a/lib/qs.js
+++ b/lib/qs.js
@@ -25,7 +25,7 @@ var qs = function(str, del, eq) {
 
 var unescape = function(str) {
   try {
-    str = decodeURIComponent(str).replace(/\+/g, ' ');
+    str = decodeURIComponent(str.replace(/\+/g, ' '));
   } finally {
     return str.replace(/\0/g, '');
   }


### PR DESCRIPTION
If a plus is legitimately included in the post then it is stripped out and replaced with a space.  The plus should be valid if it's there after the decode.
