### PR TITLE
Fixed bug where passing in invalid data would throw errors instead of passing them through next()

### DIFF
--- a/lib/json.js
+++ b/lib/json.js
@@ -382,10 +382,10 @@ Parser.prototype._unexpected = function(tok) {
 };
 
 Parser.prototype._error = function(err) {
-  this.destroy();
   this.emit('error', typeof err === 'string'
     ? new Error(err)
     : err);
+  this.destroy();
 };
 
 Parser.prototype.destroy = function(err) {

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -37,9 +37,10 @@ var Parser = function(type, options) {
 
   this.options = options || {};
 
+  this.invalidBoundary = false;
   var key = grab(type, 'boundary');
   if (!key) {
-    return this._error('No boundary key found.');
+    this.invalidBoundary = true;
   }
 
   this.key = new Buffer('\r\n--' + key);
@@ -50,6 +51,7 @@ var Parser = function(type, options) {
   }, this);
 
   this.state = 'start';
+  this.checkedBoundary = false;
   this.pending = 0;
   this.written = 0;
   this.writtenDisk = 0;
@@ -71,6 +73,9 @@ Parser.prototype.write = function(data) {
   if (!this.writable
       || this.epilogue) return;
 
+  if (this.invalidBoundary)
+    return this._error('No boundary key found.');
+  
   try {
     this._parse(data);
   } catch (e) {
@@ -312,10 +317,10 @@ Parser.prototype._reset = function() {
 };
 
 Parser.prototype._error = function(err) {
-  this.destroy();
   this.emit('error', typeof err === 'string'
     ? new Error(err)
     : err);
+  this.destroy();
 };
 
 Parser.prototype.destroy = function(err) {


### PR DESCRIPTION
Hi!

I discovered a problem where invalid data would cause the middleware to throw rather than passing it to `next()`.

The first part of the problem was in `Parser._error()` (for both affected parsers). Since `Parser.destroy()` resets all event listeners, and `Parser._error()` was calling `destroy()` before emitting the error, the event listeners never got notified, causing EventEmitter to just throw the error.

The second part of the problem was in the `Parser` class of `multipart.js`. Since the boundary key check was happening in the constructor, any external code wouldn't have the opportunity to listen on the `error` event + catch it. I fixed this by delaying the error emission to any `write()` calls, which seems to work for my cases but definitely let me know if you think there's a better spot to move that check.

Let me know if there's anything else you need to get this merged. Thanks!

P.S.: Here's the test case that I used to reproduce the error:

``` javascript
parted = require("./index");

var _request = function(type) {
  var req = new (require('stream').Stream)();

  req.headers = {
    'content-type': type
  };

  req.destroy = function() {
    return this;
  };

  return req;
};

var makeReq = function(type, stream) {
  var baddata = "dfsgkads==jhf-ga}asd?fs=&df&";

  var req = _request(type);

  var m = parted({ stream: stream });

  m(req, {}, function(err) {
    if(err) console.log("yay we got an err for "+type+"!", err);

    var obj = req.body;
    console.log(type+" parsed:", obj);

  });

  var half = baddata.length / 2 << 0;
  req.emit('data', new Buffer(baddata.slice(0, half), 'utf8'));
  req.emit('data', new Buffer(baddata.slice(half), 'utf8'));
  req.emit('end');
}

makeReq("application/x-www-form-urlencoded", true);
makeReq("application/x-www-form-urlencoded", false);
makeReq("application/json", true);
makeReq("application/json", false);
makeReq("multipart/form-data", true);
makeReq("multipart/form-data", false);
```
